### PR TITLE
Update update_aliyun_com.sh

### DIFF
--- a/update_aliyun_com.sh
+++ b/update_aliyun_com.sh
@@ -197,7 +197,7 @@ enable_domain() {
 # 获取子域名解析记录列表
 describe_domain() {
 	local value type; local ret=0
-	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" || write_log 14 "服务器通信失败"
+	aliyun_transfer "Action=DescribeSubDomainRecords" "SubDomain=${__HOST}.${__DOMAIN}" "Type=${__TYPE}" || write_log 14 "服务器通信失败"
 	json_cleanup; json_load "$(cat "$DATFILE" 2> /dev/null)" >/dev/null 2>&1
 	json_get_var value "TotalCount"
 	if [ $value -eq 0 ]; then


### PR DESCRIPTION
目前版本当1个子域名既有A记录也有AAAA记录时，会出现更新错乱的情况，比如把A记录改写成了AAAA记录，导致同一个子域名同时有2个AAAA记录，引发问题。

所以在 describe_domain() 获取子域名列表时，加上一个 Type=A 或者 AAAA 的限制，让程序只获取1条记录，从而避免 A 记录和 AAAA 记录混在一起的麻烦。

小菜鸟提一个小意见，望采纳。